### PR TITLE
Fix version suggester script

### DIFF
--- a/utils/VersionSuggester.py
+++ b/utils/VersionSuggester.py
@@ -16,6 +16,7 @@ from logging import StreamHandler, Formatter
 from datetime import datetime
 from utils.SGTUtils import SGTFormatter
 from utils.VulnChecker import fetch_osv
+from utils.GenerateReport_Archive import suggest_upgrade_version
 # Custom formatter (assumes SGTFormatter is defined elsewhere or should be implemented here)
 try:
     from zoneinfo import ZoneInfo  # Python 3.9+
@@ -95,13 +96,13 @@ def main():
     pkg_name = args.package  # used in suggest_safe_minor_upgrade
 
     versions = get_all_versions(pkg_name)
-    basic = suggest_upgrade_version(pkg, versions, args.current)
+    basic = suggest_upgrade_version(versions, args.current)
     print(f"Suggested upgrade: {basic}")
 
     if args.safe_minor:
         safe = asyncio.run(
-        suggest_safe_minor_upgrade(pkg_name, args.current, versions)
-    )
+            suggest_safe_minor_upgrade(pkg_name, args.current, versions)
+        )
         print(f"Safe minor upgrade: {safe}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix missing import and variable usage in VersionSuggester

## Testing
- `python3 -m py_compile utils/*.py GenerateReport.py`

------
https://chatgpt.com/codex/tasks/task_e_68593b4184988327a4e947268e87100b