### PR TITLE
Improve upgrade instructions in reports

### DIFF
--- a/.github/workflows/GenerateReport.yml
+++ b/.github/workflows/GenerateReport.yml
@@ -140,7 +140,7 @@ jobs:
             attachments=""
           else
             subject="🔐 Personal Report - ${{ env.UPGRADE_COUNT }} packages need upgrade"
-            echo -e "Hello team,\n\n🔧 Number of packages needing upgrade: ${{ env.UPGRADE_COUNT }}\n\n📦 Package list and custodian:\n${{ env.UPGRADE_PKG_LIST }}\n\nRegards,\nReport Bot" > "$body_file"
+            echo -e "Hello team,\n\n🔧 Number of packages needing upgrade: ${{ env.UPGRADE_COUNT }}\n\n📦 Package list, custodian and instructions:\n${{ env.UPGRADE_PKG_LIST }}\n\nRegards,\nReport Bot" > "$body_file"
             attachments="-a temp/PersonalReport.csv -a temp/PersonalReport.html"
           fi
 

--- a/utils/InstructionFormatter.py
+++ b/utils/InstructionFormatter.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Utilities to convert upgrade instruction JSON to human-readable text."""
+
+from typing import Any, Mapping
+
+
+def instruction_to_text(instruction: Mapping[str, Any] | None) -> str:
+    """Return a human-readable string from an upgrade instruction dict."""
+    if not instruction:
+        return ""
+    base_pkg = instruction.get("base_package", "")
+    deps = instruction.get("dependencies", []) or []
+    if deps:
+        dep_str = ", ".join(deps)
+        return f"Upgrade {base_pkg} and update dependencies: {dep_str}"
+    return f"Upgrade {base_pkg}"
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: InstructionFormatter.py '<json-string>'")
+        sys.exit(1)
+
+    try:
+        data = json.loads(sys.argv[1])
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON: {e}")
+        sys.exit(1)
+
+    print(instruction_to_text(data))

--- a/utils/UpgradeInstruction.py
+++ b/utils/UpgradeInstruction.py
@@ -160,6 +160,26 @@ def generate_upgrade_instruction(base_package: str, target_version: str) -> dict
     }
     return instruction
 
+
+def generate_current_dependency_json(base_package: str,
+                                     current_version: str,
+                                     requires_dist: list[str]) -> dict:
+    """Return current version info with dependency versions."""
+    deps: list[str] = []
+    for dep in requires_dist:
+        try:
+            req = Requirement(dep)
+            ver = _extract_min_version(req)
+            if ver:
+                deps.append(f"{req.name}=={ver}")
+        except Exception as e:  # pragma: no cover - lenient parse
+            logger.warning(f"Failed to parse dependency {dep}: {e}")
+
+    return {
+        "base_package": f"{base_package}=={current_version}",
+        "dependencies": deps,
+    }
+
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Generate secure upgrade instructions")


### PR DESCRIPTION
## Summary
- add InstructionFormatter to convert JSON instructions to text
- generate current version dependency JSON
- skip upgrade instructions when unnecessary
- exclude NotUsed packages from summary counts
- include instructions in personal report email

## Testing
- `python -m py_compile GenerateReport.py utils/UpgradeInstruction.py utils/InstructionFormatter.py`

------
https://chatgpt.com/codex/tasks/task_e_685bab0efcec83278f99367d4025ffaf