### PR TITLE
Sync dev branch after generating reports

### DIFF
--- a/.github/workflows/GenerateReport.yml
+++ b/.github/workflows/GenerateReport.yml
@@ -466,3 +466,9 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+
+  sync-main-to-dev:
+    name: Sync main to dev
+    needs: create-weekly-release
+    uses: ./.github/workflows/SyncMainToDev.yml
+    secrets: inherit

--- a/.github/workflows/SyncMainToDev.yml
+++ b/.github/workflows/SyncMainToDev.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary
- allow SyncMainToDev workflow to be reusable
- call SyncMainToDev at the end of GenerateReport workflow

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685cba5078e48327b3a5f38694518ac9